### PR TITLE
add eception handling for getting pool info

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -304,12 +304,14 @@ BlockController.prototype.list = function (req, res) {
 };
 
 BlockController.prototype.getPoolInfo = function (block) {
-    var coinbaseBuffer = block.transactions[0].inputs[0]._scriptBuffer;
+    if (block.transactions[0]) {
+      var coinbaseBuffer = block.transactions[0].inputs[0]._scriptBuffer;
 
-    for (var k in this.poolStrings) {
-        if (coinbaseBuffer.toString('utf-8').match(k)) {
-            return this.poolStrings[k];
-        }
+      for (var k in this.poolStrings) {
+          if (coinbaseBuffer.toString('utf-8').match(k)) {
+              return this.poolStrings[k];
+          }
+      }
     }
 
     return {};


### PR DESCRIPTION
fresh build and blockchain sync - getting this error:
```
[2019-02-27T03:37:54.397Z] error: TypeError: Cannot read property 'inputs' of undefined
    at BlockController.getPoolInfo (/xzc-node/node_modules/insight-api-zcoin/lib/blocks.js:307:47)
    at BlockController.transformBlock (/xzc-node/node_modules/insight-api-zcoin/lib/blocks.js:140:24)
    at /xzc-node/node_modules/insight-api-zcoin/lib/blocks.js:76:40
    at /xzc-node/node_modules/async/lib/async.js:676:51
    at /xzc-node/node_modules/async/lib/async.js:726:13
    at /xzc-node/node_modules/async/lib/async.js:52:16
    at /xzc-node/node_modules/async/lib/async.js:264:21
    at /xzc-node/node_modules/async/lib/async.js:44:16
    at /xzc-node/node_modules/async/lib/async.js:723:17
    at /xzc-node/node_modules/async/lib/async.js:167:37
```